### PR TITLE
Fix #6 - Add editor container style mixin

### DIFF
--- a/ace-widget.html
+++ b/ace-widget.html
@@ -21,6 +21,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   #editor {
     border: 1px solid #e3e3e3;
     border-radius: 4px;
+    @apply(--ace-widget-editor);
   }
 </style>
 <template>


### PR DESCRIPTION
I've added a simple `--ace-widget-editor` mixin, so users can customize the editor container appearance. See issue #6 for more info.
