### PR TITLE
Use caret for Polymer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   "ignore": [
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#~1.5.0",
+    "polymer": "Polymer/polymer#^1.5.0",
     "ace-builds": "~1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It would be nice to use caret for Polymer resolution. Currently our components uses caret but we run into dependency conflict when using the latest version of Polymer (1.6.0) because of ace-widget resolution to 1.5.0.

Please note google seem to be using caret resolution for Polymer in their Paper/Iron/... elements as well.
