### PR TITLE
Declare basePath before setting theme on init

### DIFF
--- a/ace-widget.html
+++ b/ace-widget.html
@@ -145,8 +145,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
         this.head = document.head;
 
-        this.themeChanged();
         ace.config.set('basePath', this.resolveUrl('../ace-builds/src-min-noconflict/'));
+        this.themeChanged();
         this.editorValue = "";
         editor.setOption('enableSnippets', this.enableSnippets);
         editor.setOption('enableBasicAutocompletion', true);


### PR DESCRIPTION
When using the component in a bundled build, I encountered fails when ace tried to load the theme.
This little change will fix that.

Thanks for creating this nice little element 🎉